### PR TITLE
Remove 'include_raw_content' from TAVILY_DEFAULT_CONFIG

### DIFF
--- a/run_evaluation.py
+++ b/run_evaluation.py
@@ -27,7 +27,6 @@ if not logger.handlers:
 
 TAVILY_DEFAULT_CONFIG = {
     "search_depth": "advanced",
-    "include_raw_content": True,
     "max_results": 10,
 }
 


### PR DESCRIPTION
Removed 'include_raw_content' from default config.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `include_raw_content` from the Tavily default configuration in `run_evaluation.py`.
> 
> - Updates `TAVILY_DEFAULT_CONFIG` to only include `search_depth` and `max_results`; fallback config on load failure now reflects this change
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c3a81a5de71e919cb99090555e33dd30ede62f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->