### PR TITLE
fix: bump aiohttp to 3.13.4 (security vulnerabilities)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.13.3
+aiohttp==3.13.4
 gpt_researcher==0.13.3
 langchain_openai==0.3.18
 pandas==2.2.3


### PR DESCRIPTION
## Summary
- Bumps aiohttp from 3.13.3 to 3.13.4
- Fixes multiple medium/low severity vulnerabilities: duplicate Host header acceptance, response splitting, header injection, cookie leakage, multipart size bypass

## Test plan
- [ ] Verify service works correctly